### PR TITLE
Log any exceptions to PHP's error log

### DIFF
--- a/qa-hipchat-notifications-event.php
+++ b/qa-hipchat-notifications-event.php
@@ -71,8 +71,12 @@ class qa_hipchat_notifications_event {
 
     if ($token && $room) {
       $hc = new HipChat\HipChat($token);
-
-      $result = $hc->message_room($room, $sender, $message, $notify, $color);
+      try{
+        $result = $hc->message_room($room, $sender, $message, $notify, $color);
+      }
+      catch (HipChat\HipChat_Exception $e) {
+        error_log($e->getMessage());
+      }
     }
   }
 }


### PR DESCRIPTION
Here's my pull request for Issue #1. I couldn't think of a good way to actually alert if there is an error, so I'm instead saving it directly to PHP's error log file.

I didn't want to alert on the screen anywhere since the user who triggered the error isn't the one who should be seeing it.
